### PR TITLE
Changed character selector from [i] to .charAt(i) so ie7 would be happy.

### DIFF
--- a/string_score.js
+++ b/string_score.js
@@ -43,7 +43,7 @@ String.prototype.score = function(abbreviation, fuzziness) {
      ++i) {
     
     // Find the first case-insensitive match of a character.
-    c = abbreviation[i];
+    c = abbreviation.charAt(i);
     
     index_c_lowercase = string.indexOf(c.toLowerCase());
     index_c_uppercase = string.indexOf(c.toUpperCase());


### PR DESCRIPTION
ie7 can't handle "banana"[2], but loves it some "banana".charAt(2).
